### PR TITLE
Fixes the library not loading any events

### DIFF
--- a/AutoStreamDeck/Events/SendEvents/SetTitleEvent.cs
+++ b/AutoStreamDeck/Events/SendEvents/SetTitleEvent.cs
@@ -21,8 +21,17 @@ namespace AutoStreamDeck.Events.SendEvents
 
     internal class SetTitlePayload
     {
+        /// <summary>
+        /// Title to display; when no title is specified, the title will reset to the title set by the user.
+        /// </summary>
         public string title { get; }
+        /// <summary>
+        /// Specifies which aspects of the Stream Deck should be updated, hardware, software, or both.
+        /// </summary>
         public Target target { get; }
+        /// <summary>
+        /// Action state the request applies to; when no state is supplied, the title is set for both states. Note, only applies to multi-state actions.
+        /// </summary>
         public int state { get; }
 
         public SetTitlePayload(string title, Target target, int state)

--- a/AutoStreamDeck/Extensions/ReflectionHelpers.cs
+++ b/AutoStreamDeck/Extensions/ReflectionHelpers.cs
@@ -19,22 +19,12 @@ namespace AutoStreamDeck.Extensions
 			if (assemblies == null)
 				assemblies = new Assembly[0];
 			ReflectedAssemblies = assemblies
+				// Load the entry assembly
 				.With(Assembly.GetEntryAssembly())
-				.Select(x => Assembly.Load(x.GetName()))
+				// Load the library assembly
+                .With(Assembly.GetAssembly(typeof(ReflectionHelpers)))
+                .Select(x => Assembly.Load(x.GetName()))
 				.ToArray();
-			/*
-			PathAssemblyResolver resolver = new PathAssemblyResolver(
-				assemblies
-					.With(typeof(Type).Assembly)
-					.With(Assembly.GetEntryAssembly())
-					.Select(x => x.Location)
-				);
-			metadataLoader = new MetadataLoadContext(resolver, typeof(Type).Assembly.GetName().ToString());
-			ReflectedAssemblies = assemblies
-				.With(Assembly.GetEntryAssembly())
-				.Select(x => metadataLoader.LoadFromAssemblyPath(x.Location))
-				.ToArray();
-			*/
 		}
 
 	}

--- a/ExamplePlugin/Program.cs
+++ b/ExamplePlugin/Program.cs
@@ -18,6 +18,8 @@ if (Debugger.IsAttached)
 	return;
 }
 
+StreamDeck.ShowDebugConsole();
+
 try
 {
 	// Wait for the application to launch


### PR DESCRIPTION
Adds some more logging, and fixes the library not loading any events.

This issue was caused because while we were loading the calling assembly, we were not loading the library's assembly meaning that no events were able to be located via reflection.